### PR TITLE
Filter out pages that only have newlines in their description

### DIFF
--- a/generators/search-map.js
+++ b/generators/search-map.js
@@ -6,7 +6,7 @@ var writeFile = Q.denodeify(fs.writeFile);
 var mkdirs = Q.denodeify(require("fs-extra").mkdirs);
 var striptags = require("striptags");
 var bitDocsHelpers = require('bit-docs-generate-html/build/make_default_helpers');
-	
+
 /**
  * @function bitDocs.generators.searchMap.searchMap
  * @parent bitDocs.generators.searchMap.methods
@@ -26,26 +26,26 @@ module.exports = function(docMap, siteConfig) {
 		for (name in docMap) {
 			if (docMap.hasOwnProperty(name)) {
 				var docObj = docMap[name];
+				var description = docObj.description && docObj.description.trim();
 				var signaturesHaveContent = docObj.signatures && docObj.signatures.some(function(signature){
 					return signature.params || signature.return || signature.options;
 				});
 				// If there is no body, it's likely we don't want to index it
-				if(docObj.description || signaturesHaveContent){
+				if (description || signaturesHaveContent) {
 					var helpers = bitDocsHelpers(docMap, siteConfig, function(){
 						return docObj;
 					}, {});
-					
-					var description = helpers.makeHtml(docObj.description);
-					description = helpers.makeLinks(description);
-					description = striptags(description, 
-						// Allowed tags
-						['a', 'em', 'code']
-					);
+
+					// Convert bit-docs markdown to HTML
+					var descriptionAsHTML = helpers.makeLinks(helpers.makeHtml(description));
+
+					// Only allow certain HTML elements
+					var descriptionAsStrippedHTML = striptags(descriptionAsHTML, ['a', 'code', 'em', 'strong']);
 
 					var searchObj = {
 						name: docObj.name,
 						title: docObj.title,
-						description: description,
+						description: descriptionAsStrippedHTML,
 						url: filename(docObj, siteConfig),
 						dest: 'doc/'
 					};

--- a/testDocMap.json
+++ b/testDocMap.json
@@ -170,6 +170,7 @@
   "Component": {
     "name": "Component",
     "type": "add",
+    "description": "\n",
     "signature": []
   }
 }


### PR DESCRIPTION
Also refactor the code a bit so it’s more readable.